### PR TITLE
fix: 静的エクスポートとi18n設定の競合を解決

### DIFF
--- a/.firebaserc
+++ b/.firebaserc
@@ -1,0 +1,15 @@
+{
+  "projects": {
+    "default": "line-bot-407102"
+  },
+  "targets": {
+    "line-bot-407102": {
+      "hosting": {
+        "kazukiasao-portfolio": [
+          "kazukiasao-portfolio"
+        ]
+      }
+    }
+  },
+  "etags": {}
+}

--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,5 @@ next-env.d.ts
 
 # firebase
 .firebase/
-.firebaserc
 firebase-debug.log
 .firebase*.json

--- a/next.config.ts
+++ b/next.config.ts
@@ -13,12 +13,6 @@ const nextConfig: NextConfig = {
   // Firebase Hosting用の静的エクスポート設定
   output: "export",
 
-  // 多言語対応設定
-  i18n: {
-    locales: ["ja", "en"],
-    defaultLocale: "ja",
-  },
-
   // MDXをページとして扱うための設定
   pageExtensions: ["js", "jsx", "ts", "tsx", "md", "mdx"],
 
@@ -26,6 +20,7 @@ const nextConfig: NextConfig = {
   reactStrictMode: true,
   images: {
     domains: ["github.com", "zenn.dev"], // 画像最適化対象ドメイン
+    unoptimized: true, // 静的エクスポート時は画像最適化を無効化
   },
 };
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -23,14 +23,12 @@ export const metadata: Metadata = {
 
 export default function RootLayout({
   children,
-  params: { locale },
 }: Readonly<{
   children: React.ReactNode;
-  params: { locale: string };
 }>) {
   return (
     <html 
-      lang={locale || "ja"} 
+      lang="ja" 
       suppressHydrationWarning
     >
       <body

--- a/src/components/sections/BlogSection.tsx
+++ b/src/components/sections/BlogSection.tsx
@@ -3,7 +3,7 @@
 import { useState } from 'react'
 import { motion } from 'framer-motion'
 import Link from 'next/link'
-import Image from 'next/image'
+// import Image from 'next/image' // TODO: 画像実装時に有効化
 
 // 記事カテゴリタイプ
 type CategoryType = 'All' | 'React' | 'Next.js' | 'TypeScript' | 'AI'

--- a/src/components/sections/ContactSection.tsx
+++ b/src/components/sections/ContactSection.tsx
@@ -41,6 +41,7 @@ export default function ContactSection() {
         subject: '',
         message: '',
       })
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
     } catch (_error) {
       // 送信失敗
       setSubmitStatus('error')

--- a/src/components/sections/ContactSection.tsx
+++ b/src/components/sections/ContactSection.tsx
@@ -41,7 +41,7 @@ export default function ContactSection() {
         subject: '',
         message: '',
       })
-    } catch (error) {
+    } catch (_error) {
       // 送信失敗
       setSubmitStatus('error')
     } finally {

--- a/src/components/sections/ProjectsSection.tsx
+++ b/src/components/sections/ProjectsSection.tsx
@@ -3,7 +3,7 @@
 import { useState } from 'react'
 import { motion } from 'framer-motion'
 import Link from 'next/link'
-import Image from 'next/image'
+// import Image from 'next/image' // TODO: 画像実装時に有効化
 
 // プロジェクトのモックデータ
 const projects = [

--- a/src/components/sections/SkillsSection.tsx
+++ b/src/components/sections/SkillsSection.tsx
@@ -2,7 +2,7 @@
 
 import { motion } from 'framer-motion'
 import { PieChart, Pie, Cell, ResponsiveContainer, Tooltip } from 'recharts'
-import Image from 'next/image'
+// import Image from 'next/image' // TODO: 画像実装時に有効化
 
 // 言語使用割合のサンプルデータ
 const languageData = [

--- a/src/components/theme-provider.tsx
+++ b/src/components/theme-provider.tsx
@@ -22,6 +22,7 @@ const ThemeProviderContext = createContext<ThemeProviderState | undefined>(undef
 export function ThemeProvider({
   children,
   defaultTheme = "system",
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   attribute: _attribute = "class",
   enableSystem = true,
   disableTransitionOnChange = false,

--- a/src/components/theme-provider.tsx
+++ b/src/components/theme-provider.tsx
@@ -22,7 +22,7 @@ const ThemeProviderContext = createContext<ThemeProviderState | undefined>(undef
 export function ThemeProvider({
   children,
   defaultTheme = "system",
-  attribute = "class",
+  attribute: _attribute = "class",
   enableSystem = true,
   disableTransitionOnChange = false,
 }: ThemeProviderProps) {


### PR DESCRIPTION
- i18n設定を削除（静的エクスポートと互換性がないため）
- 画像最適化をunoptimized: trueに設定

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Removed multilingual (i18n) configuration from the application.
  - Disabled image optimization during static export.
  - Temporarily disabled image components in several sections pending future implementation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->